### PR TITLE
Use setAsync with parens

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ env.addExtension('SetAsyncExtension', new SetAsyncExtension())
 {% setAsync 'numberofAstronauts', getNumberOfAstronauts, [] %}
 <p> There are {{numberofAstronauts}} in space right now! </p>
 ```
+Or you can also use `setAsync` with parens as follow:
+
+``` html
+{% setAsync('numberofAstronauts', getNumberOfAstronauts, []) %}
+<p> There are {{numberofAstronauts}} in space right now! </p>
+```
+
 - index.js
 ``` js
 env.render('template.html', function(err, res) {

--- a/index.js
+++ b/index.js
@@ -2,8 +2,15 @@ function SetAsyncExtension() {
     this.tags = ['setAsync'];
 
     this.parse = function(parser, nodes, lexer) {
+        var args;
         var tok = parser.nextToken();
-        var args = parser.parseSignature(null, true);
+
+        try {
+          args = parser.parseSignature(null, false);
+        } catch(e) {
+          args = parser.parseSignature(null, true);
+        }
+
         parser.advanceAfterBlockEnd(tok.value);
 
         return new nodes.CallExtensionAsync(this, 'run', args);

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -6,7 +6,7 @@ const SetAsyncExtension = require('./../index');
 let assert = require('assert');
 describe('SetAsyncExtension', function() {
   describe('setAsync', function() {
-    it('should render the template with My async content', function(done) {
+    it('should render the template with My async content using setAsync without parens', function(done) {
       let env = new nunjucks.Environment();
       env.addExtension('SetAsyncExtension', new SetAsyncExtension());
       env.addGlobal('test', function(cb) {
@@ -15,6 +15,20 @@ describe('SetAsyncExtension', function() {
         }, 50);
       });
       env.renderString("{% setAsync 'name', test, [] %}{{name}}", (err, content) => {
+        assert.equal('My async content', content)
+        done();
+      })
+    });
+
+    it('should render the template with My async content using setAsync with parens', function(done) {
+      let env = new nunjucks.Environment();
+      env.addExtension('SetAsyncExtension', new SetAsyncExtension());
+      env.addGlobal('test', function(cb) {
+        setTimeout(_ => {
+          cb(null, 'My async content');
+        }, 50);
+      });
+      env.renderString("{% setAsync ('name', test, []) %}{{name}}", (err, content) => {
         assert.equal('My async content', content)
         done();
       })


### PR DESCRIPTION
This PR adds the ability to use `setAsync` with parens, essentially making it look like a function call:

`{% setAsync ('name', test, []) %}`